### PR TITLE
Pcl conversions timestamp

### DIFF
--- a/include/DataHandlerClass.h
+++ b/include/DataHandlerClass.h
@@ -19,6 +19,8 @@
 #include <pcl/point_types.h>
 #include <visualization_msgs/Marker.h>
 #include <cmath>
+#include <pcl_conversions/pcl_conversions.h>
+
 #define COUNT_SYNC_MAX 2
 
 class DataUARTHandler{

--- a/src/DataHandlerClass.cpp
+++ b/src/DataHandlerClass.cpp
@@ -348,9 +348,7 @@ void *DataUARTHandler::sortIncomingData( void )
                 mmwData.numObjOut = mmwData.header.numDetectedObj;
             }
             
-            RScan->header.stamp = ros::Time::now();
-            RScan->header.frame_id = frameID;
-            
+            pcl_conversions::toPCL(ros::Time::now(), RScan->header.stamp);
             RScan->height = 1;
             RScan->width = mmwData.numObjOut;
             RScan->is_dense = 1;

--- a/src/DataHandlerClass.cpp
+++ b/src/DataHandlerClass.cpp
@@ -348,10 +348,9 @@ void *DataUARTHandler::sortIncomingData( void )
                 mmwData.numObjOut = mmwData.header.numDetectedObj;
             }
             
-            // RScan->header.seq = 0;
-            // RScan->header.stamp = (uint64_t)(ros::Time::now());
-            // RScan->header.stamp = (uint32_t) mmwData.header.timeCpuCycles;
+            RScan->header.stamp = ros::Time::now();
             RScan->header.frame_id = frameID;
+            
             RScan->height = 1;
             RScan->width = mmwData.numObjOut;
             RScan->is_dense = 1;


### PR DESCRIPTION
Using PCL Conversions function to allow resulting pointcloud message to have a well-defined timestamp